### PR TITLE
Add support for Xbox One controllers with the original 2016 firmware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(${PROJECT_NAME}
   src/controllers/dualshock4_controller.cpp
   src/controllers/dualsense_controller.cpp
   src/controllers/xbox_one_controller.cpp
+  src/controllers/xbox_one_controller_2016.cpp
   src/controllers/switch_pro_controller.cpp
 )
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -7,6 +7,7 @@
 #include "controllers/dualshock4_controller.h"
 #include "controllers/dualsense_controller.h"
 #include "controllers/xbox_one_controller.h"
+#include "controllers/xbox_one_controller_2016.h"
 #include "controllers/switch_pro_controller.h"
 
 inline void* operator new(std::size_t, void* __p) throw() { return __p; }
@@ -27,7 +28,7 @@ Controller *Controller::makeController(uint32_t mac0, uint32_t mac1, int port)
         DECL_CONTROLLER(0x054C, 0x05C4, DualShock4Controller);
         DECL_CONTROLLER(0x054C, 0x09CC, DualShock4Controller);
         DECL_CONTROLLER(0x054C, 0x0CE6, DualSenseController);
-        DECL_CONTROLLER(0x045E, 0x02E0, XboxOneController);
+        DECL_CONTROLLER(0x045E, 0x02E0, XboxOneController2016);
         DECL_CONTROLLER(0x045E, 0x02FD, XboxOneController);
         DECL_CONTROLLER(0x045E, 0x0B00, XboxOneController);
         DECL_CONTROLLER(0x045E, 0x0B05, XboxOneController);

--- a/src/controllers/xbox_one_controller_2016.cpp
+++ b/src/controllers/xbox_one_controller_2016.cpp
@@ -1,0 +1,62 @@
+#include <psp2kern/ctrl.h>
+
+#include "xbox_one_controller_2016.h"
+
+XboxOneController2016::XboxOneController2016(uint32_t mac0, uint32_t mac1, int port): Controller(mac0, mac1, port)
+{
+    // Send an empty write request just to receive a response
+    static uint8_t report[4] = {};
+    requestReport(HID_REQUEST_WRITE, report, sizeof(report));
+}
+
+void XboxOneController2016::processReport(uint8_t *buffer, size_t length)
+{
+    // Only process the report if it's of the right type
+    if (buffer[0] != 0x01)
+        return;
+
+    // Interpret the data as an input report
+    XboxOne2016Report0x01 *report = (XboxOne2016Report0x01*)buffer;
+
+    // Clear the old control data
+    controlData.buttons = 0;
+
+    // Map the face buttons
+    if (report->a) controlData.buttons |= SCE_CTRL_CROSS;
+    if (report->b) controlData.buttons |= SCE_CTRL_CIRCLE;
+    if (report->y) controlData.buttons |= SCE_CTRL_TRIANGLE;
+    if (report->x) controlData.buttons |= SCE_CTRL_SQUARE;
+
+    // Map the D-pad
+    int dpad = report->dpad - 1;
+    if (dpad == DPAD_NW || dpad == DPAD_N || dpad == DPAD_NE)
+        controlData.buttons |= SCE_CTRL_UP;
+    if (dpad == DPAD_NE || dpad == DPAD_E || dpad == DPAD_SE)
+        controlData.buttons |= SCE_CTRL_RIGHT;
+    if (dpad == DPAD_SE || dpad == DPAD_S || dpad == DPAD_SW)
+        controlData.buttons |= SCE_CTRL_DOWN;
+    if (dpad == DPAD_SW || dpad == DPAD_W || dpad == DPAD_NW)
+        controlData.buttons |= SCE_CTRL_LEFT;
+
+    // Map the triggers
+    if (report->lb)       controlData.buttons |= SCE_CTRL_L1;
+    if (report->rb)       controlData.buttons |= SCE_CTRL_R1;
+    if (report->triggerL) controlData.buttons |= SCE_CTRL_LTRIGGER;
+    if (report->triggerR) controlData.buttons |= SCE_CTRL_RTRIGGER;
+    if (report->stickL)   controlData.buttons |= SCE_CTRL_L3;
+    if (report->stickR)   controlData.buttons |= SCE_CTRL_R3;
+
+    // Map the menu buttons
+    if (report->menu)  controlData.buttons |= SCE_CTRL_START;
+    if (report->view)  controlData.buttons |= SCE_CTRL_SELECT;
+    // TODO: Guide is actually in a report with type 0x02, not here
+    // if (report->guide) controlData.buttons |= SCE_CTRL_PSBUTTON;
+
+    // Map the sticks
+    controlData.leftX  = report->leftX  >> 8;
+    controlData.leftY  = report->leftY  >> 8;
+    controlData.rightX = report->rightX >> 8;
+    controlData.rightY = report->rightY >> 8;
+
+    // TODO: implement battery level
+}

--- a/src/controllers/xbox_one_controller_2016.h
+++ b/src/controllers/xbox_one_controller_2016.h
@@ -1,0 +1,50 @@
+#ifndef XBOX_ONE_CONTROLLER_2016_H
+#define XBOX_ONE_CONTROLLER_2016_H
+
+#include "../controller.h"
+
+struct XboxOne2016Report0x01
+{
+    uint8_t reportId;
+
+    uint16_t leftX;
+    uint16_t leftY;
+    uint16_t rightX;
+    uint16_t rightY;
+
+    uint16_t triggerL;
+    uint16_t triggerR;
+
+    uint8_t dpad;
+
+    uint8_t a    : 1;
+    uint8_t b    : 1;
+    uint8_t x    : 1;
+    uint8_t y    : 1;
+    uint8_t lb   : 1;
+    uint8_t rb   : 1;
+    uint8_t view : 1;
+    uint8_t menu : 1;
+
+    uint8_t stickL : 1;
+    uint8_t stickR : 1;
+    uint8_t guide  : 1; // NOTE: Guide is not actually here, it's in a report with a different header
+    uint8_t        : 3;
+    uint8_t        : 1;
+    uint8_t        : 0;
+
+    uint8_t : 1;
+    uint8_t : 0;
+
+}
+__attribute__((packed));
+
+class XboxOneController2016: public Controller
+{
+    public:
+        XboxOneController2016(uint32_t mac0, uint32_t mac1, int port);
+
+        void processReport(uint8_t *buffer, size_t length);
+};
+
+#endif // XBOX_ONE_CONTROLLER_2016_H


### PR DESCRIPTION
The original firmware for the Xbox One controllers used a slightly different report format, with most buttons bunched up together in one byte.

I've added support for this older firmware before, to SDL and the like. Adding it here makes it work great on my vita!

For reference, controllers reporting a PID of 0x02FD are the first revision with the current report format, 0x2E0 is the only PID I know that has the older one.

I'm not hugely familiar with C++, so if there's a nicer way to do this that doesn't involve quite so much duplication I'm all ears. Thanks!